### PR TITLE
Add support for the log crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,13 @@ warn_debug = []
 warn_release = []
 disable_release = []
 
+# Use the `log` crate instead of printing to STDERR
+# WARNING: If the allocation failure happens during a logger call, then
+#          depending on the logger's implementation this may block indefinitely
+log = ["dep:log"]
+
+[dependencies]
+log = { version = "0.4", optional = true }
+
 [package.metadata.docs.rs]
 features = ["warn_debug"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,7 +162,7 @@ impl AllocDisabler {
 				#[cfg(feature = "log")]
 				permit_alloc(|| log::error!("Memory allocation of {} bytes failed", layout.size()));
 
-        #[cfg(feature = "backtrace")]
+				#[cfg(feature = "backtrace")]
 				permit_alloc(|| eprintln!("Allocation failure from:\n{:?}", backtrace::Backtrace::new()));
 
 				// This handler can be overridden (although as of writing, the API to do so is still

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,17 +150,22 @@ pub struct AllocDisabler;
 
 #[cfg(not(all(feature = "disable_release", not(debug_assertions))))] // if not disabled
 impl AllocDisabler {
-	fn check(&self, _layout: Layout) {
+	fn check(&self, layout: Layout) {
 		let forbid_count = ALLOC_FORBID_COUNT.with(|f| f.get());
 		let permit_count = ALLOC_PERMIT_COUNT.with(|p| p.get());
 		if forbid_count > 0 && permit_count == 0 {
-			// we may not use println! here, as it will stall when unwinding from a panic.
-
 			#[cfg(any( all(feature="warn_debug", debug_assertions), all(feature="warn_release", not(debug_assertions)) ))] // if warn mode is selected
 			ALLOC_VIOLATION_COUNT.with(|c| c.set(c.get()+1));
 
 			#[cfg(any( all(not(feature="warn_debug"), debug_assertions), all(not(feature="warn_release"), not(debug_assertions)) ))] // if abort mode is selected
-			std::alloc::handle_alloc_error(_layout);
+			{
+				#[cfg(feature = "log")]
+				permit_alloc(|| log::error!("Memory allocation of {} bytes failed", layout.size()));
+
+				// This handler can be overridden (although as of writing, the API to do so is still
+				// unstable) so we must always call this even when the log feature is enabled
+				std::alloc::handle_alloc_error(layout);
+			}
 		}
 	}
 }


### PR DESCRIPTION
This is useful when the log output is going somewhere other than STDERR. I've added this for a fork to use with NIH-plug, but I thought others might find it useful as well. This will sadly still print the original allocation failure message from `std::alloc::handle_alloc_error` in addition to the log output as that handler function must be called here.

I didn't know what the preferred way to integrate this into an example or test case would be so I haven't done either of those things in this PR.