### PR TITLE
Add support for printing backtraces on failure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,11 @@ warn_debug = []
 warn_release = []
 disable_release = []
 
+# Print a backtrace before aborting the program when an allocation failure happens
+backtrace = ["dep:backtrace"]
+
+[dependencies]
+backtrace = { version = "0.3", optional = true }
+
 [package.metadata.docs.rs]
 features = ["warn_debug"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -160,7 +160,12 @@ impl AllocDisabler {
 			ALLOC_VIOLATION_COUNT.with(|c| c.set(c.get()+1));
 
 			#[cfg(any( all(not(feature="warn_debug"), debug_assertions), all(not(feature="warn_release"), not(debug_assertions)) ))] // if abort mode is selected
-			std::alloc::handle_alloc_error(_layout);
+			{
+				#[cfg(feature = "backtrace")]
+				permit_alloc(|| eprintln!("Allocation failure from:\n{:?}", backtrace::Backtrace::new()));
+
+				std::alloc::handle_alloc_error(_layout);
+			}
 		}
 	}
 }


### PR DESCRIPTION
This makes it much simpler to know where the allocation failure is coming from. I've combined #9 and this PR into a single branch for use in NIH-plug here: https://github.com/robbert-vdh/rust-assert-no-alloc/tree/nih-plug